### PR TITLE
Added support for %{var} like placholders in graph url (titles, data etc...)

### DIFF
--- a/graphite_graph.rb
+++ b/graphite_graph.rb
@@ -39,7 +39,8 @@ class GraphiteGraph
                    :draw_null_as_zero => false,
                    :major_grid_line_color => nil,
                    :minor_grid_line_color => nil,
-                   :area => :none}.merge(@overrides)
+                   :area => :none,
+                   :placeholders => nil}.merge(@overrides)
   end
 
   def [](key)
@@ -304,7 +305,10 @@ class GraphiteGraph
     url_parts << "format=#{format}" if format
 
     if url
-       URI.encode(url_parts.join("&"))
+      url_str = url_parts.join("&")
+      properties[:placeholders].each { |k,v| url_str.gsub!("%{#{k}}", v.to_s) } if properties[:placeholders].is_a?(Hash)
+
+      URI.encode(url_str)
     else
       url_parts
     end


### PR DESCRIPTION
Hi!

I have added support for %{var} like placeholders that allows user to use them anywhere in graph url.

Example usage in config file:

```
placeholders :host => 'myhost', :country => 'uk'
title 'Data for %{host} (%{country})'

field :first,
  :alias => '%{country} max',
  :data  => '%{host}.countries.%{country}.max'

field :second,
  :alias => '%{country} avg',
  :data  => '%{host}.countries.%{country}.avg'
```

I have plan to implement and use this functionality in GDash to allow system/dashboard wide placeholders. (Eg country based dashboard that accepts country code as url parameter).
