### PR TITLE
Allow aliasing to be turned off

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -301,6 +301,8 @@ class GraphiteGraph
             graphite_target = "aliasByNode(#{graphite_target},#{target[:alias_by_node]})"
           elsif target[:alias]
             graphite_target = "alias(#{graphite_target},\"#{target[:alias]}\")"
+          elsif target[:no_alias]
+            graphite_target = graphite_target # no-op
           else
             graphite_target = "alias(#{graphite_target},\"#{name.to_s.capitalize}\")"
           end


### PR DESCRIPTION
This is a simple fix to turn aliasing off. It allows using custom functions on the target instead of limiting to only a few. This also resolves issues around this bug:

https://bugs.launchpad.net/graphite/+bug/890279

as a substr on the target can be used in place of it to achieve the same result until 0.9.10 final is released.
