### PR TITLE
URL placeholders broken by CGI escapes

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -357,8 +357,8 @@ class GraphiteGraph
     url_parts << "format=#{format}" if format
 
     if url
+      properties[:placeholders].each { |k,v| url_parts.each {|part| part.gsub!("%{#{k}}", v.to_s) } } if properties[:placeholders].is_a?(Hash)
       url_str = url_parts.map { |pair| k,v = pair.split('='); "#{k}=#{CGI.escape(v)}" }.join("&")
-      properties[:placeholders].each { |k,v| url_str.gsub!("%{#{k}}", v.to_s) } if properties[:placeholders].is_a?(Hash)
 
       url_str
     else


### PR DESCRIPTION
This commit fixes placeholders which broke in 08c3c0560c6a3d2f8a0404f8d986953ac7330874.
