### PR TITLE
Remove unused variable colors

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -264,7 +264,6 @@ class GraphiteGraph
     return nil if properties[:surpress]
 
     url_parts = []
-    colors = []
 
     [:title, :vtitle, :from, :width, :height, :until].each do |item|
       url_parts << "#{item}=#{properties[item]}" if properties[item]


### PR DESCRIPTION
The colors variable is unused (per a 1.9 ruby -c syntax check). Perhaps this line is from a time when graphite did not support the color() function.

I remember that time, and in fact this code looks quite familiar to me ;)
