### PR TITLE
Support for graphite templates

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -56,6 +56,7 @@ class GraphiteGraph
                    :logbase => nil,
                    :placeholders => nil,
                    :area_alpha => nil,
+                   :theme => nil,
                    :unique_legend => nil}.merge(@overrides)
   end
 
@@ -301,6 +302,7 @@ class GraphiteGraph
     url_parts << "areaAlpha=#{properties[:area_alpha]}" if properties[:area_alpha]
     url_parts << "minXStep=#{properties[:min_x_step]}" if properties[:min_x_step]
     url_parts << "uniqueLegend=#{properties[:unique_legend]}" if properties[:unique_legend]
+    url_parts << "template=#{properties[:theme]}" if properties[:theme]
 
     target_order.each do |name|
       target = targets[name]


### PR DESCRIPTION
This PR adds support for the template parameter of the render api (e. g. what you define in graphTemplates.conf of you graphite installation).

Naming the parameter `:template` didn't work, so I named it `:theme` instead.
