### PR TITLE
Make scale() and scaleToSeconds() independent.

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -323,11 +323,8 @@ class GraphiteGraph
           graphite_target = "nonNegativeDerivative(#{graphite_target})"
         end
         graphite_target = "highestAverage(#{graphite_target},#{target[:highest_average]})" if target[:highest_average]
-        if target[:scale]
-          graphite_target = "scale(#{graphite_target},#{target[:scale]})"
-        elsif target[:scale_to_seconds]
-          graphite_target = "scaleToSeconds(#{graphite_target},#{target[:scale_to_seconds]})"
-        end
+        graphite_target = "scale(#{graphite_target},#{target[:scale]})" if target[:scale]
+        graphite_target = "scaleToSeconds(#{graphite_target},#{target[:scale_to_seconds]})" if target[:scale_to_seconds]
         if target[:as_percent] == true
           graphite_target = "asPercent(#{graphite_target})"
         elsif target[:as_percent]


### PR DESCRIPTION
They don't need to be mutually exclusive, consider Rx bytes on an
interface, sampled per minute and you want bits/sec:

scaleToSeconds(scale(some.host.interface.octets.eth0.rx,8),1)
