### PR TITLE
allow alias_by_node to take a list of nodes as an argument

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -347,7 +347,11 @@ class GraphiteGraph
 
         unless target.include?(:subgroup)
           if target[:alias_by_node]
-            graphite_target = "aliasByNode(#{graphite_target},#{target[:alias_by_node]})"
+            if target[:alias_by_node].is_a? Array
+              graphite_target = "aliasByNode(#{graphite_target},#{target[:alias_by_node].join(",")})"
+            else:
+              graphite_target = "aliasByNode(#{graphite_target},#{target[:alias_by_node]})"
+            end
           elsif target[:alias_sub_search]
             graphite_target = "aliasSub(#{graphite_target},\"#{target[:alias_sub_search]}\",\"#{target[:alias_sub_replace]}\")"
           elsif target[:alias]


### PR DESCRIPTION
Graphite supports the nodes as *args for the AliasByNode option. You can
work around this buy just passing in "1,2,3,4.." as a string however I
feel that using an array makes more sense.  I may be wrong.
