### PR TITLE
Fix for data[target] having nil

### DIFF
--- a/bin/check_graph.rb
+++ b/bin/check_graph.rb
@@ -52,25 +52,26 @@ def check_data(data, min, max)
   fails = []
 
   data.keys.each do |target|
+    data["#{target}"].compact!
     if min == max # we got just one value to compare against
       if min < 0
         # if the threshold is < 0 we check for values below the threshold but have no way to say that
         # critical / warning is above -0.5 for example unless you specify a 2 value band
-        if (data[target].min <= min)
-          fails << {:target => target, :item => data[target].min, :operator => "<=", :expected => min}
+        if (data["#{target}"].min <= min)
+          fails << {:target => target, :item => data["#{target}"].min, :operator => "<=", :expected => min}
         end
       else
-        if (data[target].max >= max)
-          fails << {:target => target, :item => data[target].max, :operator => ">=", :expected => max}
+        if (data["#{target}"].max >= max)
+          fails << {:target => target, :item => data["#{target}"].max, :operator => ">=", :expected => max}
         end
       end
     else # we have a range of values to compare against and the values must be between
-      if (data[target].min <= min)
-        fails << {:target => target, :item => data[target].min, :operator => "<=", :expected => min}
+      if (data["#{target}"].min <= min)
+        fails << {:target => target, :item => data["#{target}"].min, :operator => "<=", :expected => min}
       end
 
-      if (data[target].max >= max)
-        fails << {:target => target, :item => data[target].max, :operator => ">=", :expected => max}
+      if (data["#{target}"].max >= max)
+        fails << {:target => target, :item => data["#{target}"].max, :operator => ">=", :expected => max}
       end
     end
   end


### PR DESCRIPTION
Compacting data[target] -- if data[target] has nil, we get a "ArgumentError: comparison of Float with nil failed" at data[target].min/max
