### PR TITLE
Values should be derived before summing

### DIFF
--- a/lib/graphite_graph.rb
+++ b/lib/graphite_graph.rb
@@ -298,12 +298,12 @@ class GraphiteGraph
         graphite_target = target[:data]
 
         graphite_target = "keepLastValue(#{graphite_target})" if target[:keep_last_value]
-        graphite_target = "sum(#{graphite_target})" if target[:sum]
         if target[:derivative]
           graphite_target = "derivative(#{graphite_target})"
         elsif target[:non_negative_derivative]
           graphite_target = "nonNegativeDerivative(#{graphite_target})"
         end
+        graphite_target = "sum(#{graphite_target})" if target[:sum]
         graphite_target = "highestAverage(#{graphite_target},#{target[:highest_average]})" if target[:highest_average]
         if target[:scale]
           graphite_target = "scale(#{graphite_target},#{target[:scale]})"


### PR DESCRIPTION
The `sum` function should be applied after the `derive`/`non_negative_derivate` functions, otherwise you end up with weird spikes like this:

![](http://i.imgur.com/OM7o9an.png)

The `keep_last_value` function can be used to alleviate this but in some situations seeing gaps in the graphs is useful/desired.
